### PR TITLE
Usage message with compose <= 1.22

### DIFF
--- a/nimbusapp
+++ b/nimbusapp
@@ -129,7 +129,7 @@ prompt_recreate() {
 check_recreate() {
     local composeFile="$1"
 
-    local containers=($(docker-compose -p "$PROJECT" -f "$COMPOSE_FILE" ps -aq))
+    local containers=($(docker-compose -p "$PROJECT" -f "$COMPOSE_FILE" ps -q))
     local recreate=()
 
     local service hash composeHash name


### PR DESCRIPTION
## Fixed:
* Usage message with docker-compose version <= 1.22

This bug negates the 1.2 recreate check.