### PR TITLE
Prevent conflicts, only allow one instance of running test suite

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,10 +100,12 @@ pipeline {
 
         stage('Test') {
             steps {
-                sh '''
-                    export PATH="$PWD/bats-core/libexec/bats-core:$PATH"
-                    bats tests --tap | tee bats-tap.log
-                '''
+                lock('nimbusapp-test') {
+                    sh '''
+                        export PATH="$PWD/bats-core/libexec/bats-core:$PATH"
+                        bats tests --tap | tee bats-tap.log
+                    '''
+                }
             }
             post {
                 always {


### PR DESCRIPTION
If multiple branches run tests at the same time, they will interfere with each other by creating or deleting the same containers, and creating multiple copies of the docker network used during testing.

Lock the stage to force branches to queue at the testing stage when necessary. Only really occurs when  merging pull requests, as master and the merged branch kick off builds at the same time.