### PR TITLE
1.3 Offline Use, Remember Version/Repo

### DIFF
--- a/nimbusapp
+++ b/nimbusapp
@@ -510,6 +510,11 @@ if [[ -n "${DOCKERAPP_ACTION}" ]]; then
     fi # curl check
 fi
 
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+    echo -e "${C_RED}ERROR${C_REG}: Could not find ${IMAGE}:${VERSION} (${PROJECT}) - do you need to create it with \`nimbusapp up'" >&2
+    exit 1
+fi
+
 if [[ "$COMPOSE_ACTION" == "down" && "$NIMBUS_FORCE" -eq 0 ]]; then
     if ! prompt_delete; then
         exit 1

--- a/nimbusapp
+++ b/nimbusapp
@@ -37,6 +37,78 @@ function version_info() {
     output "Released on $NIMBUS_RELEASE_DATE"
 }
 
+# Ensure the apps.config file is initialized
+#
+# Also upgrades from v1 to v2 file format.
+# v2 includes project name, tries to eliminate extra .dockerapps, and is a bit easier to parse
+function apps_init() {
+    # If v2 file exists, nothing to do
+    if grep '^\s*#\s*v2\s*$' "$file" >/dev/null 2>&1; then
+        return
+    fi
+
+    local template="# v2"
+    local file="${1-$ENV_FILE}"
+    local tmp="${file}.tmp$$"
+    local backup="${file}.v1-backup"
+
+    local proj img repo tag
+
+    # Easy path, no file! Create it and return
+    if [[ ! -f "$file" ]]; then
+        echo $template > "$file"
+        return
+    fi
+
+    mv "$file" "$tmp"
+    echo $template > "$file"
+
+    while read proj img; do
+        proj="${proj%.dockerapp}"
+        IFS=/: read repo img tag <<< $img
+
+        echo $proj $repo $img $tag
+    done < "$tmp" > "$file"
+
+    mv "$tmp" "$backup"
+}
+
+function apps_load() {
+    apps_init
+
+    local search="${1-$PROJECt}"
+    local file="${2-$ENV_FILE}"
+    local entry proj repo img ver
+
+    debug "Searching apps for: ${search}"
+
+    entry="$(grep "^${search}\b" "${file}")"
+
+    debug "Apps found: ${entry}"
+
+    if [[ -n $entry ]]; then
+        read proj repo img ver <<< $entry
+
+        REPOSITORY="${REPOSITORY-$repo}"
+        VERSION="${VERSION-$ver}"
+        IMAGE="${IMAGE-$img}"
+    fi
+}
+
+function apps_save() {
+    apps_init
+
+    local file="${1-$ENV_FILE}"
+
+    debug "Saving: $PROJECT $REPOSITORY $IMAGE $VERSION"
+
+    # Remove previous entry for this project
+    sed -i "/$PROJECT\b/d" "$file"
+
+    # Write new entry
+    echo $PROJECT $REPOSITORY $IMAGE $VERSION >> "$file"
+}
+
 # create folders to use for mount points
 # currently not leverated by Intellij
 function create_intellij_mount_points (){
@@ -324,78 +396,6 @@ while [[ "$1" != "" ]]; do
         exit 1
     esac
 done
-
-# Ensure the apps.config file is initialized
-#
-# Also upgrades from v1 to v2 file format.
-# v2 includes project name, tries to eliminate extra .dockerapps, and is a bit easier to parse
-function apps_init() {
-    # If v2 file exists, nothing to do
-    if grep '^\s*#\s*v2\s*$' "$file" >/dev/null 2>&1; then
-        return
-    fi
-
-    local template="# v2"
-    local file="${1-$ENV_FILE}"
-    local tmp="${file}.tmp$$"
-    local backup="${file}.v1-backup"
-
-    local proj img repo tag
-
-    # Easy path, no file! Create it and return
-    if [[ ! -f "$file" ]]; then
-        echo $template > "$file"
-        return
-    fi
-
-    mv "$file" "$tmp"
-    echo $template > "$file"
-
-    while read proj img; do
-        proj="${proj%.dockerapp}"
-        IFS=/: read repo img tag <<< $img
-
-        echo $proj $repo $img $tag
-    done < "$tmp" > "$file"
-
-    mv "$tmp" "$backup"
-}
-
-function apps_load() {
-    apps_init
-
-    local search="${1-$PROJECt}"
-    local file="${2-$ENV_FILE}"
-    local entry proj repo img ver
-
-    debug "Searching apps for: ${search}"
-
-    entry="$(grep "^${search}\b" "${file}")"
-
-    debug "Apps found: ${entry}"
-
-    if [[ -n $entry ]]; then
-        read proj repo img ver <<< $entry
-
-        REPOSITORY="${REPOSITORY-$repo}"
-        VERSION="${VERSION-$ver}"
-        IMAGE="${IMAGE-$img}"
-    fi
-}
-
-function apps_save() {
-    apps_init
-
-    local file="${1-$ENV_FILE}"
-
-    debug "Saving: $PROJECT $REPOSITORY $IMAGE $VERSION"
-
-    # Remove previous entry for this project
-    sed -i "/$PROJECT\b/d" "$file"
-
-    # Write new entry
-    echo $PROJECT $REPOSITORY $IMAGE $VERSION >> "$file"
-}
 
 if [[ "$IMAGE" == */* ]]; then
     IFS=/ read REPOSITORY IMAGE <<< $IMAGE

--- a/nimbusapp
+++ b/nimbusapp
@@ -210,20 +210,20 @@ NETWORK_GATEWAY="${NETWORK_GATEWAY-172.50.0.1}"
 
 ENV_FILE="${NIMBUS_BASEDIR}/apps.config"
 
-IMAGE="$1"
+if [[ "$1" != "-"* ]]; then
+    IMAGE="$1"
 
-shift
-if [[ "${IMAGE}" = *"help"* ]]; then
-    usage
-    exit 0
+    shift
+    if [[ "${IMAGE}" = *"help"* ]]; then
+        usage
+        exit 0
+    fi
+
+    if [[ "${IMAGE}" = *"version"* ]]; then
+        version_info
+        exit 0
+    fi
 fi
-
-if [[ "${IMAGE}" = *"version"* ]]; then
-    version_info
-    exit 0
-fi
-
-# IMAGE="admpresales/${IMAGE}.dockerapp"
 
 while [[ "$1" != "" ]]; do
     PARAM="$1"
@@ -319,26 +319,31 @@ while [[ "$1" != "" ]]; do
     esac
 done
 
-# aka is_apps_v2
-function apps_v2_check() {
-    local file="${1-$ENV_FILE}"
-    grep '^\s*#\s*v2\s*$' "$file" >/dev/null 2>&1
-}
-
-# Original record:
-#   something.dockerapp someorg/something:1.0
+# Ensure the apps.config file is initialized
 #
-# Desired record:
-#   someproject someorg something 1.0
-function apps_v2_upgrade() {
+# Also upgrades from v1 to v2 file format.
+# v2 includes project name, tries to eliminate extra .dockerapps, and is a bit easier to parse
+function apps_init() {
+    # If v2 file exists, nothing to do
+    if grep '^\s*#\s*v2\s*$' "$file" >/dev/null 2>&1; then
+        return
+    fi
+
+    local template="# v2"
     local file="${1-$ENV_FILE}"
     local tmp="${file}.tmp$$"
     local backup="${file}.v1-backup"
 
     local proj img repo tag
 
+    # Easy path, no file! Create it and return
+    if [[ ! -f "$file" ]]; then
+        echo $template > "$file"
+        return
+    fi
+
     mv "$file" "$tmp"
-    apps_v2_create
+    echo $template > "$file"
 
     while read proj img; do
         proj="${proj%.dockerapp}"
@@ -350,31 +355,31 @@ function apps_v2_upgrade() {
     mv "$tmp" "$backup"
 }
 
-function apps_v2_create() {
-    local file="${1-$ENV_FILE}"
+function apps_load() {
+    apps_init
 
-    echo '# v2' > "$file"
-
-# apps.config v2 format
-# <project> <organization> <image> <version>
-}
-
-function apps_v2_load() {
-    local file="${1-$ENV_FILE}"
+    local search="${1-$PROJECt}"
+    local file="${2-$ENV_FILE}"
     local entry proj repo img ver
 
-    entry="$(grep "^$IMAGE\b" "${file}")"
+    debug "Searching apps for: ${search}"
+
+    entry="$(grep "^${search}\b" "${file}")"
+
+    debug "Apps found: ${entry}"
 
     if [[ -n $entry ]]; then
         read proj repo img ver <<< $entry
 
         REPOSITORY="${REPOSITORY-$repo}"
         VERSION="${VERSION-$ver}"
-        IMAGE="$img"
+        IMAGE="${IMAGE-$img}"
     fi
 }
 
-function apps_v2_save() {
+function apps_save() {
+    apps_init
+
     local file="${1-$ENV_FILE}"
 
     debug "Saving: $PROJECT $REPOSITORY $IMAGE $VERSION"
@@ -386,15 +391,6 @@ function apps_v2_save() {
     echo $PROJECT $REPOSITORY $IMAGE $VERSION >> "$file"
 }
 
-if [[ -f "$ENV_FILE" ]]; then
-    if ! apps_v2_check; then
-        debug "Upgrading $ENV_FILE to v2 file format"
-        apps_v2_upgrade
-    fi
-else
-    apps_v2_create
-fi
-
 if [[ "$IMAGE" == */* ]]; then
     IFS=/ read REPOSITORY IMAGE <<< $IMAGE
 fi
@@ -403,11 +399,19 @@ if [[ "$IMAGE" == *:* ]]; then
     IFS=: read IMAGE VERSION <<< $IMAGE
 fi
 
-apps_v2_load
-
 #create a project name for the docker-compose based on the image name.
-if [[ -z ${PROJECT} ]]; then
-    PROJECT="$(basename $IMAGE .dockerapp)"
+if [[ -z $PROJECT ]]; then
+
+    if [[ -z $IMAGE ]]; then
+        echo "ERROR: Please specify an image or project name." >&2
+        exit 1;
+    fi
+
+    PROJECT="${IMAGE%.dockerapp}"
+fi
+
+if [[ -n $PROJECT ]]; then
+    apps_load "${PROJECT}"
 fi
 
 # Apply defaults if necessary
@@ -420,7 +424,10 @@ debug "Image: $IMAGE"
 debug "Version: $VERSION"
 debug "Project: $PROJECT"
 
-apps_v2_save
+if [[ -z $IMAGE ]]; then
+    echo "ERROR: Could not determine image name. Please specify an image or project name." >&2
+    exit 1
+fi
 
 if [[ -z "${COMPOSE_ACTION}" && -z "${DOCKERAPP_ACTION}" ]]; then
     output "You must specify a command"
@@ -436,6 +443,12 @@ COMPOSE_FILE="${COMPOSE_DIR}/${IMAGE}.yml"
 COMPOSE_BACKUP="${COMPOSE_FILE}.bk"
 
 if [[ -n "${DOCKERAPP_ACTION}" ]]; then
+    if ! docker login; then
+        rc=$?
+        output "Docker login failed ($rc)" >&2
+        exit $rc
+    fi
+
     if curl -s --connect-timeout "${NIMBUS_DOCKERHUB_TIMEOUT}" "${NIMBUS_DOCKERHUB_URL}" > /dev/null 2>&1; then
         DOCKERAPP_COMMAND="${DOCKERAPP_COMMAND} ${DOCKERAPP_ACTION} ${DOCKERAPP_ARGS} ${REPOSITORY}/${IMAGE}:${VERSION}"
 
@@ -506,5 +519,11 @@ fi
 if [[ -n "${COMPOSE_ACTION}" ]]; then
     COMPOSE_COMMAND="${COMPOSE_COMMAND} -p ${PROJECT} -f ${COMPOSE_FILE} ${COMPOSE_ACTION} ${COMPOSE_ARGS}"
     debug "Running: ${COMPOSE_COMMAND}"
-    eval "${COMPOSE_COMMAND}"
+    if ! eval "${COMPOSE_COMMAND}"; then
+        rc=$?
+        echo "Failed to run compose: $rc" >&2
+        exit $rc
+    fi
 fi
+
+apps_save

--- a/nimbusapp
+++ b/nimbusapp
@@ -37,18 +37,6 @@ function version_info() {
     output "Released on $NIMBUS_RELEASE_DATE"
 }
 
-function product_exists(){
-    #if we find an entry, return 0 for success, else 1 for failure
-    local image="$(echo $IMAGE | cut -d'.' -f1 ).dockerapp"
-
-    if [[ $(grep "^${image}\b" ${ENV_FILE} -c) -eq 1 ]]
-    then
-        return 0
-    else
-        return 1
-    fi
-}
-
 # create folders to use for mount points
 # currently not leverated by Intellij
 function create_intellij_mount_points (){
@@ -193,8 +181,9 @@ readonly NIMBUS_RELEASE_DATE="UNRELEASED"
 
 BASH_VERBOSE=""
 
-REPOSITORY="admpresales"
-VERSION="latest"
+DEFAULT_REPOSITORY="admpresales"
+DEFAULT_VERSION="latest"
+
 PROJECT=""
 VOLUME_MOUNT_IDEA=""
 VOLUME_MOUNT_M2=""
@@ -234,25 +223,6 @@ if [[ "${IMAGE}" = *"version"* ]]; then
     exit 0
 fi
 
-if [[ "$IMAGE" == *\/* ]]; then
-    REPOSITORY=$(echo $IMAGE | cut -d'/' -f1 )
-    IMAGE=$(echo $IMAGE | cut -d'/' -f2 )
-fi
-
-if [[ "$IMAGE" == *:* ]]; then
-    VERSION=$(echo $IMAGE | cut -d':' -f2 )
-    IMAGE=$(echo $IMAGE | cut -d':' -f1 )
-elif [[ -e $ENV_FILE ]]; then
-    if product_exists; then
-        #ensuring uniform comparision since someone could pass intillij or intellij.dockerapp
-        IMAGE=$(echo $IMAGE | cut -d'.' -f1 )".dockerapp"
-        VERSION=$(grep "^${IMAGE}\b" ${ENV_FILE} | cut -d':' -f2 )
-        output "Using ${IMAGE}:${VERSION} version found in ${ENV_FILE}"
-    else
-        output "Not able to find ${IMAGE} in ${ENV_FILE}.  Will attempt to start using ${IMAGE}:${VERSION}"
-    fi
-fi
-
 # IMAGE="admpresales/${IMAGE}.dockerapp"
 
 while [[ "$1" != "" ]]; do
@@ -279,6 +249,7 @@ while [[ "$1" != "" ]]; do
         append_dockerapp_arg "$PARAM" "$VALUE"
         shift 2
         ;;
+    # TODO: Intellij checks should happen after image parsing
     -v)
          # check to see if intellij is being called.
         if [[ "${IMAGE}" == *intellij* ]]
@@ -336,6 +307,109 @@ while [[ "$1" != "" ]]; do
     esac
 done
 
+# aka is_apps_v2
+function apps_v2_check() {
+    local file="${1-$ENV_FILE}"
+    grep '^\s*#\s*v2\s*$' "$file" >/dev/null 2>&1
+}
+
+# Original record:
+#   something.dockerapp someorg/something:1.0
+#
+# Desired record:
+#   someproject someorg something 1.0
+function apps_v2_upgrade() {
+    local file="${1-$ENV_FILE}"
+    local tmp="${file}.tmp$$"
+    local backup="${file}.v1-backup"
+
+    local proj img repo tag
+
+    mv "$file" "$tmp"
+    apps_v2_create
+
+    while read proj img; do
+        proj="${proj%.dockerapp}"
+        IFS=/: read repo img tag <<< $img
+
+        echo $proj $repo $img $tag
+    done < "$tmp" > "$file"
+
+    mv "$tmp" "$backup"
+}
+
+function apps_v2_create() {
+    local file="${1-$ENV_FILE}"
+
+    echo '# v2' > "$file"
+
+# apps.config v2 format
+# <project> <organization> <image> <version>
+}
+
+function apps_v2_load() {
+    local file="${1-$ENV_FILE}"
+    local entry proj repo img ver
+
+    entry="$(grep "^$IMAGE\b" "${file}")"
+
+    if [[ -n $entry ]]; then
+        read proj repo img ver <<< $entry
+
+        REPOSITORY="${REPOSITORY-$repo}"
+        VERSION="${VERSION-$ver}"
+        IMAGE="$img"
+    fi
+}
+
+function apps_v2_save() {
+    local file="${1-$ENV_FILE}"
+
+    debug "Saving: $PROJECT $REPOSITORY $IMAGE $VERSION"
+
+    # Remove previous entry for this project
+    sed -i "/$PROJECT\b/d" "$file"
+
+    # Write new entry
+    echo $PROJECT $REPOSITORY $IMAGE $VERSION >> "$file"
+}
+
+if [[ -f "$ENV_FILE" ]]; then
+    if ! apps_v2_check; then
+        debug "Upgrading $ENV_FILE to v2 file format"
+        apps_v2_upgrade
+    fi
+else
+    apps_v2_create
+fi
+
+if [[ "$IMAGE" == */* ]]; then
+    IFS=/ read REPOSITORY IMAGE <<< $IMAGE
+fi
+
+if [[ "$IMAGE" == *:* ]]; then
+    IFS=: read IMAGE VERSION <<< $IMAGE
+fi
+
+apps_v2_load
+
+#create a project name for the docker-compose based on the image name.
+if [[ -z ${PROJECT} ]]; then
+    PROJECT="$(basename $IMAGE .dockerapp)"
+fi
+
+# Apply defaults if necessary
+REPOSITORY="${REPOSITORY-$DEFAULT_REPOSITORY}"
+VERSION="${VERSION-$DEFAULT_VERSION}"
+IMAGE="${IMAGE%.dockerapp}"
+
+debug "Repository: $REPOSITORY"
+debug "Image: $IMAGE"
+debug "Version: $VERSION"
+debug "Project: $PROJECT"
+
+apps_v2_save
+
 if [[ -z "${COMPOSE_ACTION}" && -z "${DOCKERAPP_ACTION}" ]]; then
     output "You must specify a command"
     usage
@@ -344,16 +418,10 @@ fi
 
 create_network
 
-#create a project name for the docker-compose based on the image name.
-if [[ -z ${PROJECT} ]]; then
-    PROJECT="$(basename $IMAGE .dockerapp)"
-fi
-
 COMPOSE_ARGS="$@"
 COMPOSE_DIR="${NIMBUS_BASEDIR}/cache/${PROJECT}/${REPOSITORY}/${IMAGE}/${VERSION}"
 COMPOSE_FILE="${COMPOSE_DIR}/${IMAGE}.yml"
 COMPOSE_BACKUP="${COMPOSE_FILE}.bk"
-
 
 if [[ -n "${DOCKERAPP_ACTION}" ]]; then
     if curl -s --connect-timeout "${NIMBUS_DOCKERHUB_TIMEOUT}" "${NIMBUS_DOCKERHUB_URL}" > /dev/null 2>&1; then

--- a/nimbusapp
+++ b/nimbusapp
@@ -296,7 +296,14 @@ while [[ "$1" != "" ]]; do
         ;;
     up)
         DOCKERAPP_ACTION="render"
-        COMPOSE_ACTION="up -d"
+        
+        # Start in background if required
+        if [[ "$@" == *"--no-start"* ]]; then
+            COMPOSE_ACTION="up"
+        else 
+            COMPOSE_ACTION="up -d"
+        fi
+
         shift
         break
         ;;

--- a/nimbusapp
+++ b/nimbusapp
@@ -82,7 +82,7 @@ function apps_load() {
 
     debug "Searching apps for: ${search}"
 
-    entry="$(grep "^${search}\b" "${file}")"
+    entry="$(grep "^${search}\s" "${file}")"
 
     debug "Apps found: ${entry}"
 

--- a/nimbusapp
+++ b/nimbusapp
@@ -208,6 +208,8 @@ NETWORK_NAME="${NETWORK_NAME-demo-net}"
 NETWORK_SUBNET="${NETWORK_SUBNET-172.50.0.0/16}"
 NETWORK_GATEWAY="${NETWORK_GATEWAY-172.50.0.1}"
 
+PRESERVE_VOLUMES=0
+
 ENV_FILE="${NIMBUS_BASEDIR}/apps.config"
 
 if [[ "$1" != "-"* ]]; then
@@ -281,6 +283,10 @@ while [[ "$1" != "" ]]; do
         ;;
     -f|--force)
         NIMBUS_FORCE=1
+        shift
+        ;;
+    --preserve-volumes)
+        PRESERVE_VOLUMES=1
         shift
         ;;
     render|inspect)
@@ -517,8 +523,18 @@ if [[ "$COMPOSE_ACTION" == "up -d" && "$NIMBUS_FORCE" -eq 0 ]]; then
 fi
 
 if [[ -n "${COMPOSE_ACTION}" ]]; then
+    if [[ $COMPOSE_ACTION == *"up"* && $PRESERVE_VOLUMES -eq 0 ]]; then
+        COMPOSE_ARGS="$COMPOSE_ARGS -V"
+    fi
+
+    if [[ $COMPOSE_ACTION == *"down"* && $PRESERVE_VOLUMES -eq 0 ]]; then
+        COMPOSE_ARGS="$COMPOSE_ARGS -v"
+    fi
+
     COMPOSE_COMMAND="${COMPOSE_COMMAND} -p ${PROJECT} -f ${COMPOSE_FILE} ${COMPOSE_ACTION} ${COMPOSE_ARGS}"
+
     debug "Running: ${COMPOSE_COMMAND}"
+
     if ! eval "${COMPOSE_COMMAND}"; then
         rc=$?
         echo "Failed to run compose: $rc" >&2

--- a/nimbusapp
+++ b/nimbusapp
@@ -288,9 +288,14 @@ while [[ "$1" != "" ]]; do
         shift
         break
         ;;
-    down | start | stop | ps | rm | logs | restart | pull )
-        DOCKERAPP_ACTION="render"
+    down | start | stop | ps | rm | logs | restart )
         COMPOSE_ACTION="${PARAM}"
+        shift
+        break
+        ;;
+    pull)
+        DOCKERAPP_ACTION="render"
+        COMPOSE_ACTION="pull"
         shift
         break
         ;;

--- a/tests/10_cache.bats
+++ b/tests/10_cache.bats
@@ -54,3 +54,11 @@ function teardown() {
     grep "Docker Hub: 0.0.0.0:0 Timeout: 10" <<< $output
 }
 
+@test "Cache: No file" {
+
+    run "$NIMBUS_EXE" does-not-exist:1.0 start
+
+    (( status == 1 ))
+
+    grep "Could not find does-not-exist:1.0" <<< $output
+}

--- a/tests/40_config.bats
+++ b/tests/40_config.bats
@@ -23,15 +23,65 @@ function teardown() {
 
 @test "Config: Substring" {
     cat >"$NIMBUS_BASEDIR/apps.config" <<EOF
-nimbusapp-test.dockerapp admpresales/nimbusapp-test.dockerapp:0.1.0
-nimbusapp-test-fake.dockerapp admpresales/nimbusapp-test-fake.dockerapp:0.1.0
+# v2
+nimbusapp-test admpresales nimbusapp-test 0.1.0
+nimbusapp-test-fake admpresales nimbusapp-test-fake 0.1.0
 EOF
+
+    cat "$NIMBUS_BASEDIR/apps.config"
 
     # Cannot use $TEST_IMAGE here
     run "$NIMBUS_EXE" nimbusapp-test -d -f up
-
     (( status == 0 ))
+}
 
-    assert_output_contains "Using nimbusapp-test.dockerapp:0.1.0 version found in"
-    assert_not_output_contains "Not able to find nimbusapp"
+@test "Config: Remember" {
+    : > "$NIMBUS_BASEDIR/apps.config"
+
+    run "$NIMBUS_EXE" nimbusapp-test:0.1.0 -d -f up
+    (( status == 0 ))
+    assert_container_exists "$TEST_CONTAINER"
+
+    grep '^nimbusapp-test admpresales nimbusapp-test 0.1.0$' "$NIMBUS_BASEDIR/apps.config"
+
+    run "$NIMBUS_EXE" nimbusapp-test -d -f down
+    (( status == 0 ))
+    assert_not_container_exists "$TEST_CONTAINER"
+}
+
+@test "Config: Project" {
+    : > "$NIMBUS_BASEDIR/apps.config"
+
+    run "$NIMBUS_EXE" nimbusapp-test:0.1.0 -p testing -d -f up
+    (( status == 0 ))
+    assert_container_exists "$TEST_CONTAINER"
+
+    grep '^testing admpresales nimbusapp-test 0.1.0$' "$NIMBUS_BASEDIR/apps.config"
+
+    run "$NIMBUS_EXE" -p testing -d -f down
+    (( status == 0 ))
+    assert_not_container_exists "$TEST_CONTAINER"
+}
+
+@test "Config: Upgrade" {
+    cat > "$NIMBUS_BASEDIR/apps.config" <<EOF
+nimbusapp-test.dockerapp admpresales/nimbusapp-test:0.1.0
+EOF
+
+    run "$NIMBUS_EXE" nimbusapp-test ps
+
+    grep '^nimbusapp-test admpresales nimbusapp-test 0.1.0' "$NIMBUS_BASEDIR/apps.config"
+}
+
+@test "Config: Overwrite" {
+        cat > "$NIMBUS_BASEDIR/apps.config" <<EOF
+# v2
+testing admpresales nimbusapp-test wrong-version
+EOF
+
+    "$NIMBUS_EXE" nimbusapp-test:0.1.0 -p testing -d -f up
+
+    grep '^testing admpresales nimbusapp-test 0.1.0' "$NIMBUS_BASEDIR/apps.config"
+    wc -l "$NIMBUS_BASEDIR/apps.config" | cut -f1 -d' '
+    [[ "$(wc -l "$NIMBUS_BASEDIR/apps.config" | cut -f1 -d' ' | cut -f1)" -eq 2 ]]
 }


### PR DESCRIPTION
## Changed
* Format of apps.config has been updated and now includes a project field
* Do not re-render configuration on every command, this should greatly improve performance for all but a few operations
* Project (`-p`) may now be specified instead of providing an image name

## Added
* Basic volume support (adds -V/-v to `docker-compose up` and `down`)
* Support for `docker-compose up --no-start`
* Project, repository, image and version will be remembered automatically in apps.config if the command is successful