### PR TITLE
1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,89 @@ You may need to remove or rename extra copies of the script until the correct sc
 /usr/local/bin/nimbusapp
 ```
 
-## Running
+## Using Nimbusapp
 
-Please refer to the individual images on [ADM Presales Docker Hub](https://hub.docker.com/u/admpresales)
-for instructions and sample commands for running nimbusapp.
+This section provides basic usage instructions.
+Please refer to the individual dockerapp entries on [ADM Presales Docker Hub](https://hub.docker.com/u/admpresales)
+for image specific instructions.
+
+Examples use the [Nimbusapp Test Image](./tests/nimbusapp-test.dockerapp), which starts a single container with a lightweight web server.
+
+See the [Usage Text](./USAGE.txt) or `nimbusapp help` for more information.
+
+Please refer to the individual images on [ADM Presales Docker Hub](https://hub.docker.com/u/admpresales) for image-specific instructions and examples.
+
+### Gerneral Format
+
+Where possible commands mirror the `docker-compose` features which are used under the covers.
+
+```
+nimbusapp <image> <command>
+```
+
+### Create Containeres
+
+Using the `up` command will pull images, create containers and start the containers all in one operation.
+
+Version numbers are only required the first time an image is pulled, and will be remembered for future commands.
+
+```
+[demo@nimbusserver nimbusapp]$ nimbusapp nimbusapp-test:0.1.0 up
+Authenticating with existing credentials...
+Login Succeeded
+Creating nimbusapp-test-web ... done
+```
+
+To create containers from an image without starting the containers immediately, use the `--no-start` option:
+
+```
+[demo@nimbusserver nimbusapp]$ nimbusapp nimbusapp-test:0.1.0 up --no-start
+```
+
+### Check Container Status
+
+To verify the state of a container, use the `ps` command.
+
+```
+[demo@nimbusserver nimbusapp]$ nimbusapp nimbusapp-test ps
+       Name              Command        State           Ports
+---------------------------------------------------------------------
+nimbusapp-test-web   httpd-foreground   Up      0.0.0.0:12345->80/tcp
+
+```
+
+### Starting Containers
+
+To start existing containers, use the `start` command.
+
+```
+[demo@nimbusserver nimbusapp]$ nimbusapp nimbusapp-test start
+Starting web ... done
+```
+
+
+### Stopping Containers
+
+To stop running containers, use the `stop` command.
+
+```
+[demo@nimbusserver nimbusapp]$ nimbusapp nimbusapp-test stop
+Stopping nimbusapp-test-web ... done
+```
+
+### Delete Containers
+
+```
+[demo@nimbusserver nimbusapp]$ nimbusapp nimbusapp-test down
+
+This action will DELETE your containers and is IRREVERSIBLE!
+
+You may wish to use `nimbusapp ... stop' to shut down your containers without deleting them
+
+The following containers will be deleted:
+- /nimbusapp-test-web
+
+Do you wish to DELETE these containers? [y/n] y
+Stopping nimbusapp-test-web ... done
+Removing nimbusapp-test-web ... done
+```

--- a/USAGE.txt
+++ b/USAGE.txt
@@ -1,0 +1,36 @@
+Usage: nimbusapp <IMAGE>[:<VERSION>] [OPTIONS] COMMAND [CMD OPTIONS]
+
+Options:
+  IMAGE       The Docker App file you wish to run. If no repository is provided, admpresales is assumed.
+  VERSION     The version of the Docker App file you wish to run.
+              Only required the first time you create a container, will be cached for future use.
+  -d, --debug Enable debugging output (use twice for verbose bash commands)
+  -f, --force Skip all prompts - Use with caution, this option will happily delete your data without warning
+  -s, --set   Enables you to set(override) default arguments
+  --version   Print the version of nimbusapp and exit
+
+Commands:
+  down     Stop and remove containers
+  help     Prints this help message
+  inspect  Shows metadata and settings for a given application
+  logs     Shows logs for containers
+  ps       Lists containers
+  pull     Pull service images
+  render   Render the Compose file for the application
+  rm       Remove stopped containers
+  restart  Restart containers
+  start    Start existing containers
+  stop     Stop existing containers
+  up       Creates and start containers
+  version  Prints version information  
+  
+Experimental/Advanced Options:  
+  -v    Mounts volume for IdeaProject in IntelliJ container into user's home directory - EXPERIMENTAL: ONLY USE IF YOU UNDERSTAND VOLUME MOUNTS
+  -m    Mounts volume for .m2 in IntelliJ container into user's home directory - EXPERIMENTAL: ONLY USE IF YOU UNDERSTAND VOLUME MOUNTS
+  -p    Docker-compose project name to use, allows running multiple versions of the same image
+  --preserve-volumes    Do not recreate anonymous volumes
+
+Command Options:
+  up    --no-start       Create containers without starting them
+        --force-recreate Force all containers to be re-created
+        --no-recreate    Do not allow any containers to be re-created

--- a/nimbusapp
+++ b/nimbusapp
@@ -165,7 +165,7 @@ prompt_delete() {
     output "" \
         "${C_BOLD}This action will ${C_BOLD}${C_RED}DELETE${C_REG} your containers and is ${C_BOLD}${C_RED}IRREVERSIBLE${C_RESET}!" \
         "" \
-        "${C_BOLD}You may wish to use ${C_RESET}\`nimbusapp ... stop'${C_BOLD} to shut down your containers without deleting them${C_RESET}" \
+        "${C_BOLD}You may wish to use ${C_RESET}\`nimbusapp ${REPOSITORY}/${IMAGE}:${VERSION} stop'${C_BOLD} to shut down your containers without deleting them${C_RESET}" \
         "" \
         "${C_BOLD}The following containers will be deleted:${C_RESET}"
 
@@ -185,7 +185,7 @@ prompt_recreate() {
             "" \
             "${C_BOLD}Recreating containers is normal when changing their configuration, such as image, tag and ports.${C_RESET}" \
             "" \
-            "${C_BOLD}You may wish to use ${C_RESET}\`nimbusapp ... start'${C_BOLD} to start your existing containers.${C_RESET}" \
+            "${C_BOLD}You may wish to use ${C_RESET}\`nimbusapp ${REPOSITORY}/${IMAGE}:${VERSION} start'${C_BOLD} to start your existing containers.${C_RESET}" \
             "" \
             "${C_BOLD}The following containers will be recreated:${C_RESET}"
 
@@ -479,7 +479,6 @@ if [[ -n $PROJECT ]]; then
     apps_load "${PROJECT}"
 fi
 
-
 if [[ -z $VERSION ]]; then
     fatal "No version number specified!" \
         "" \
@@ -493,13 +492,10 @@ fi
 REPOSITORY="${REPOSITORY-$DEFAULT_REPOSITORY}"
 IMAGE="${IMAGE%.dockerapp}"
 
-debug "Repository: $REPOSITORY"
-debug "Image: $IMAGE"
-debug "Version: $VERSION"
-debug "Project: $PROJECT"
+output "${PROJECT}: Using $REPOSITORY/$IMAGE:$VERSION"
 
 if [[ -z $IMAGE ]]; then
-    fatal "Could not determine image name. Please specify an image or project name." >&2
+    fatal "Could not determine image name. Please specify an image or project name."
 fi
 
 if [[ -z "${COMPOSE_ACTION}" && -z "${DOCKERAPP_ACTION}" ]]; then
@@ -571,7 +567,7 @@ if [[ -n "${DOCKERAPP_ACTION}" ]]; then
         fi
     else # curl check
         if [[ ! -f "${COMPOSE_FILE}" ]]; then
-            fatal "ERROR: No connection to Docker Hub: ${NIMBUS_DOCKERHUB_URL} (${NIMBUS_DOCKERHUB_TIMEOUT}s)"
+            fatal "No connection to Docker Hub: ${NIMBUS_DOCKERHUB_URL} (${NIMBUS_DOCKERHUB_TIMEOUT}s)"
         else
             output "No connection to Docker Hub, using cached file!"
             debug "Docker Hub: ${NIMBUS_DOCKERHUB_URL} Timeout: ${NIMBUS_DOCKERHUB_TIMEOUT}"
@@ -590,7 +586,7 @@ if [[ "$COMPOSE_ACTION" == "down" && "$NIMBUS_FORCE" -eq 0 ]]; then
     fi
 fi
 
-if [[ "$COMPOSE_ACTION" == "up -d" && "$NIMBUS_FORCE" -eq 0 ]]; then
+if [[ "$COMPOSE_ACTION" == "up"* && "$NIMBUS_FORCE" -eq 0 && "$COMPOSE_ARGS" != *"--force-recreate"* ]]; then
     if ! check_recreate; then
         exit 1
     fi
@@ -609,7 +605,7 @@ if [[ -n "${COMPOSE_ACTION}" ]]; then
 
     debug "Running: ${COMPOSE_COMMAND}"
 
-    if ! eval "${COMPOSE_COMMAND}"; then
+    if ! eval "${COMPOSE_COMMAND} 2>&1 | tee -a '$NIMBUS_LOG_FILE'"; then
         rc=$?
         error "Failed to run compose: $rc"
         exit $rc

--- a/nimbusapp
+++ b/nimbusapp
@@ -6,34 +6,44 @@ function usage()
         error "$@" ""
     fi
 
-    output "Usage: nimbusapp <IMAGE>:<VERSION> [OPTIONS] COMMAND" \
-            "" \
-            "Options:" \
-            "  IMAGE       The Docker App file you wish to run. If no repository is provided, admpresales is assumed." \
-            "              dockerapp is added if not explicitly stated." \
-            "  VERSION     The version of the Docker App file you wish to run." \
-            "  -s, --set   Enables you to set(override) default arguments" \
-            "  -v          Mounts volume for IdeaProject in IntelliJ container into user's home directory - EXPERIMENTAL: ONLY USE IF YOU UNDERSTAND VOLUME MOUNTS" \
-            "  -m          Mounts volume for .m2 in IntelliJ container into user's home directory - EXPERIMENTAL: ONLY USE IF YOU UNDERSTAND VOLUME MOUNTS" \
-            "  -p          Docker-compose project name to use - EXPERIMENTAL NOT RECOMMENDED FOR CASUAL USERS" \
-            "  -d, --debug Enable debugging output (use twice for verbose bash commands)" \
-            "  -f, --force Skip all prompts - Use with caution, this option will happily delete your data without warning" \
-            "  --version   Print the version of nimbusapp and exit" \
-            "" \
-            "Commands:" \
-            "  down     Stop and remove containers" \
-            "  inspect  Shows metadata and settings for a given application" \
-            "  logs     Shows logs for containers" \
-            "  ps       Lists containers" \
-            "  pull     Pull service images" \
-            "  render   Render the Compose file for the application" \
-            "  rm       Remove stopped containers" \
-            "  restart  Restart containers" \
-            "  start    Start existing containers" \
-            "  stop     Stop existing containers" \
-            "  up       Creates and start containers" \
-            "  version  Prints version information" \
-            "  help     Prints this help message"
+    cat <<USAGE_EOF >&2
+Usage: nimbusapp <IMAGE>[:<VERSION>] [OPTIONS] COMMAND [CMD OPTIONS]
+
+Options:
+  IMAGE       The Docker App file you wish to run. If no repository is provided, admpresales is assumed.
+  VERSION     The version of the Docker App file you wish to run.
+              Only required the first time a container is created, and will be cached for future use.
+  -d, --debug Enable debugging output (use twice for verbose bash commands)
+  -f, --force Skip all prompts - Use with caution, this option will happily delete your data without warning
+  -s, --set   Enables you to set(override) default arguments
+  --version   Print the version of nimbusapp and exit
+
+Commands:
+  down     Stop and remove containers
+  help     Prints this help message
+  inspect  Shows metadata and settings for a given application
+  logs     Shows logs for containers
+  ps       Lists containers
+  pull     Pull service images
+  render   Render the Compose file for the application
+  rm       Remove stopped containers
+  restart  Restart containers
+  start    Start existing containers
+  stop     Stop existing containers
+  up       Creates and start containers
+  version  Prints version information  
+  
+Experimental/Advanced Options:  
+  -v    Mounts volume for IdeaProject in IntelliJ container into user's home directory - EXPERIMENTAL: ONLY USE IF YOU UNDERSTAND VOLUME MOUNTS
+  -m    Mounts volume for .m2 in IntelliJ container into user's home directory - EXPERIMENTAL: ONLY USE IF YOU UNDERSTAND VOLUME MOUNTS
+  -p    Docker-compose project name to use, allows running multiple versions of the same image
+  --preserve-volumes    Do not recreate anonymous volumes
+
+Command Options:
+  up    --no-start       Create containers without starting them
+        --force-recreate Force all containers to be re-created
+        --no-recreate    Do not allow any containers to be re-created
+USAGE_EOF
 
     if [[ -n "$@" ]]; then
         exit 1

--- a/nimbusapp
+++ b/nimbusapp
@@ -254,7 +254,6 @@ readonly NIMBUS_RELEASE_DATE="UNRELEASED"
 BASH_VERBOSE=""
 
 DEFAULT_REPOSITORY="admpresales"
-DEFAULT_VERSION="latest"
 
 PROJECT=""
 VOLUME_MOUNT_IDEA=""
@@ -420,9 +419,19 @@ if [[ -n $PROJECT ]]; then
     apps_load "${PROJECT}"
 fi
 
+
+if [[ -z $VERSION ]]; then
+    echo "No version number specified!" >&2
+    echo >&2
+    echo "If this is your first time using $IMAGE, please specify a version number:" >&2
+    echo "    $0 $IMAGE:<version_number> ${COMPOSE_ACTION:-$DOCKERAPP_ACTION}" >&2
+    echo >&2
+    echo "The version number you choose will be remembered for future commands." >&2
+    exit 1
+fi
+
 # Apply defaults if necessary
 REPOSITORY="${REPOSITORY-$DEFAULT_REPOSITORY}"
-VERSION="${VERSION-$DEFAULT_VERSION}"
 IMAGE="${IMAGE%.dockerapp}"
 
 debug "Repository: $REPOSITORY"

--- a/nimbusapp
+++ b/nimbusapp
@@ -548,7 +548,7 @@ if [[ -n "${DOCKERAPP_ACTION}" ]]; then
             error "Could not render"
 
             if [[ "${VERSION}" == *"_"* ]]; then
-                warn "Image name contains an underscore which is  not used by nimbusapp." \
+                warn "Image name contains an underscore which is not used by nimbusapp." \
                     "Try using ${REPOSITORY}/${IMAGE}:${VERSION%%_*} instead"
             fi
 

--- a/nimbusapp
+++ b/nimbusapp
@@ -293,6 +293,8 @@ function log() {
     shift
     local timeStamp="$(date "+%Y-%m-%d %H:%M:%S")"
 
+    mkdir -p "$(dirname $NIMBUS_LOG_FILE)"
+
     for line in "$@"; do
         if [[ -n "$line" ]]; then
             echo -e "[$timeStamp] $level - $line" >> "$NIMBUS_LOG_FILE"
@@ -492,10 +494,14 @@ fi
 REPOSITORY="${REPOSITORY-$DEFAULT_REPOSITORY}"
 IMAGE="${IMAGE%.dockerapp}"
 
-output "${PROJECT}: Using $REPOSITORY/$IMAGE:$VERSION"
-
 if [[ -z $IMAGE ]]; then
     fatal "Could not determine image name. Please specify an image or project name."
+fi
+
+if [[ "$PROJECT" == "$IMAGE" ]]; then
+    output "Using ${REPOSITORY}/${IMAGE}.dockerapp:${VERSION}" ""
+else
+    output "Using ${REPOSITORY}/${IMAGE}.dockerapp:${VERSION} (${PROJECT})" ""
 fi
 
 if [[ -z "${COMPOSE_ACTION}" && -z "${DOCKERAPP_ACTION}" ]]; then

--- a/nimbusapp
+++ b/nimbusapp
@@ -2,34 +2,44 @@
 
 function usage()
 {
-    output "Usage: nimbusapp <IMAGE>:<VERSION> [OPTIONS] COMMAND"
-    output -e ""
-    output -e "Options:"
-    output -e "  IMAGE       The Docker App file you wish to run. If no repository is provided, admpresales is assumed."
-    output -e "              dockerapp is added if not explicitly stated."
-    output -e "  VERSION     The version of the Docker App file you wish to run."
-    output -e "  -s, --set   Enables you to set(override) default arguments"
-    output -e "  -v          Mounts volume for IdeaProject in IntelliJ container into user's home directory - EXPERIMENTAL: ONLY USE IF YOU UNDERSTAND VOLUME MOUNTS"
-    output -e "  -m          Mounts volume for .m2 in IntelliJ container into user's home directory - EXPERIMENTAL: ONLY USE IF YOU UNDERSTAND VOLUME MOUNTS"
-    output -e "  -p          Docker-compose project name to use - EXPERIMENTAL NOT RECOMMENDED FOR CASUAL USERS"
-    output -e "  -d, --debug Enable debugging output (use twice for verbose bash commands)"
-    output -e "  -f, --force Skip all prompts - Use with caution, this option will happily delete your data without warning"
-    output -e "  --version   Print the version of nimbusapp and exit"
-    output -e ""
-    output -e "Commands:"
-    output -e "  down     Stop and remove containers"
-    output -e "  inspect  Shows metadata and settings for a given application"
-    output -e "  logs     Shows logs for containers"
-    output -e "  ps       Lists containers"
-    output -e "  pull     Pull service images"
-    output -e "  render   Render the Compose file for the application"
-    output -e "  rm       Remove stopped containers"
-    output -e "  restart  Restart containers"
-    output -e "  start    Start existing containers"
-    output -e "  stop     Stop existing containers"
-    output -e "  up       Creates and start containers"
-    output -e "  version  Prints version information"
-    output -e "  help     Prints this help message"
+    if [[ -n "$@" ]]; then
+        error "$@" ""
+    fi
+
+    output "Usage: nimbusapp <IMAGE>:<VERSION> [OPTIONS] COMMAND" \
+            "" \
+            "Options:" \
+            "  IMAGE       The Docker App file you wish to run. If no repository is provided, admpresales is assumed." \
+            "              dockerapp is added if not explicitly stated." \
+            "  VERSION     The version of the Docker App file you wish to run." \
+            "  -s, --set   Enables you to set(override) default arguments" \
+            "  -v          Mounts volume for IdeaProject in IntelliJ container into user's home directory - EXPERIMENTAL: ONLY USE IF YOU UNDERSTAND VOLUME MOUNTS" \
+            "  -m          Mounts volume for .m2 in IntelliJ container into user's home directory - EXPERIMENTAL: ONLY USE IF YOU UNDERSTAND VOLUME MOUNTS" \
+            "  -p          Docker-compose project name to use - EXPERIMENTAL NOT RECOMMENDED FOR CASUAL USERS" \
+            "  -d, --debug Enable debugging output (use twice for verbose bash commands)" \
+            "  -f, --force Skip all prompts - Use with caution, this option will happily delete your data without warning" \
+            "  --version   Print the version of nimbusapp and exit" \
+            "" \
+            "Commands:" \
+            "  down     Stop and remove containers" \
+            "  inspect  Shows metadata and settings for a given application" \
+            "  logs     Shows logs for containers" \
+            "  ps       Lists containers" \
+            "  pull     Pull service images" \
+            "  render   Render the Compose file for the application" \
+            "  rm       Remove stopped containers" \
+            "  restart  Restart containers" \
+            "  start    Start existing containers" \
+            "  stop     Stop existing containers" \
+            "  up       Creates and start containers" \
+            "  version  Prints version information" \
+            "  help     Prints this help message"
+
+    if [[ -n "$@" ]]; then
+        exit 1
+    else
+        exit 0
+    fi
 }
 
 function version_info() {
@@ -65,7 +75,7 @@ function apps_init() {
 
     while read proj img; do
         proj="${proj%.dockerapp}"
-        IFS=/: read repo img tag <<< $img
+        IFS=/: read repo img tag <<< "$img"
 
         echo $proj $repo $img $tag
     done < "$tmp" > "$file"
@@ -87,7 +97,7 @@ function apps_load() {
     debug "Apps found: ${entry}"
 
     if [[ -n $entry ]]; then
-        read proj repo img ver <<< $entry
+        read proj repo img ver <<< "$entry"
 
         REPOSITORY="${REPOSITORY-$repo}"
         VERSION="${VERSION-$ver}"
@@ -128,7 +138,7 @@ function prompt_yn() {
     local PROMPT_TEXT=$"${1-Continue?} [y/n]"
     local USER_ANSWER
 
-    echo -ne "${PROMPT_TEXT} "
+    echo -ne "${PROMPT_TEXT} " >&2
 
     while read USER_ANSWER; do
         case "${USER_ANSWER}" in
@@ -140,48 +150,51 @@ function prompt_yn() {
             ;;
         esac
 
-        echo -ne "${PROMPT_TEXT} "
+        echo -ne "${PROMPT_TEXT} " >&2
     done
 }
 
 # Colour codes
 readonly C_REG="\e[39m"     # Regular colour
 readonly C_BOLD="\e[1m"     # Bold font
-readonly C_RED="\e[91m"     # Red colour
+readonly C_RED="\e[31m"     # Red colour
 readonly C_RESET="\e[0m"    # Reset font and colour
+readonly C_YELLOW="\e[33m"    # Yellow colour
 
 prompt_delete() {
-    echo
-    echo -e "${C_BOLD}This action will ${C_BOLD}${C_RED}DELETE${C_REG} your containers and is ${C_BOLD}${C_RED}IRREVERSIBLE${C_RESET}!"
-    echo
-    echo -e "${C_BOLD}You may wish to use ${C_RESET}\`nimbusapp ... stop'${C_BOLD} to shut down your containers without deleting them${C_RESET}"
-    echo
-    echo -e "${C_BOLD}The following containers will be deleted:${C_RESET}"
+    output "" \
+        "${C_BOLD}This action will ${C_BOLD}${C_RED}DELETE${C_REG} your containers and is ${C_BOLD}${C_RED}IRREVERSIBLE${C_RESET}!" \
+        "" \
+        "${C_BOLD}You may wish to use ${C_RESET}\`nimbusapp ... stop'${C_BOLD} to shut down your containers without deleting them${C_RESET}" \
+        "" \
+        "${C_BOLD}The following containers will be deleted:${C_RESET}"
 
     docker-compose -p "${PROJECT}" -f "$COMPOSE_FILE" ps -q | while read id; do
-        docker inspect --format "- {{.Name}}" "$id"
+        docker inspect --format "- {{.Name}}" "$id" >&2
     done
-    echo
+
+    output ""
 
     prompt_yn "${C_BOLD}${C_RED}Do you wish to DELETE these containers?${C_RESET}"
     return $?
 }
 
 prompt_recreate() {
-    echo
-    echo -e "${C_BOLD}This action will cause one or more of your containers to be ${C_RED}DELETED${C_REG} and ${C_RED}RECREATED${C_REG}.${C_RESET}"
-    echo
-    echo -e "${C_BOLD}Recreating containers is normal when changing their configuration, such as image, tag and ports.${C_RESET}"
-    echo
-    echo -e "${C_BOLD}You may wish to use ${C_RESET}\`nimbusapp ... start'${C_BOLD} to start your existing containers.${C_RESET}"
-    echo
-    echo -e "${C_BOLD}The following containers will be recreated:${C_RESET}"
+    output  "" \
+            "${C_BOLD}This action will cause one or more of your containers to be ${C_RED}DELETED${C_REG} and ${C_RED}RECREATED${C_REG}.${C_RESET}" \
+            "" \
+            "${C_BOLD}Recreating containers is normal when changing their configuration, such as image, tag and ports.${C_RESET}" \
+            "" \
+            "${C_BOLD}You may wish to use ${C_RESET}\`nimbusapp ... start'${C_BOLD} to start your existing containers.${C_RESET}" \
+            "" \
+            "${C_BOLD}The following containers will be recreated:${C_RESET}"
 
     for c in "$@"; do
-        echo "- $c"
+        output "- $c"
     done
     
-    echo
+    output ""
+
     prompt_yn "${C_BOLD}${C_RED}Recreate the listed containers?${C_RESET}"
     return $?
 }
@@ -224,7 +237,9 @@ function append_dockerapp_arg() {
     local var
     local val
 
-    IFS== read var val <<< $2
+    IFS== read var val <<< "$2"
+
+    debug "$opt $var=$val"
 
     DOCKERAPP_ARGS="${DOCKERAPP_ARGS} ${opt} '${var}=\"${val}\"'"
     # DOCKERAPP_ARGS="${DOCKERAPP_ARGS} ${opt} ${var}=${val}"
@@ -236,17 +251,62 @@ function create_network() {
     fi
 }
 
+function _output() {
+    for line in "$@"; do
+        echo -e "$line" >&2
+    done
+}
+
 function debug() {
     if (( NIMBUS_DEBUG > 0 )); then
-        echo "$@"
+        _output "$@"
     fi
+    log "DEBUG" "$@"
 }
 
 function output() {
     if (( NIMBUS_OUTPUT > 0 )); then
-        echo "$@"
+        _output "$@"
     fi
+    log "INFO" "$@"
 }
+
+function warn() {
+    echo -ne "${C_BOLD}${C_YELLOW}WARNING:${C_RESET} " >&2
+    _output "$@"
+    log "WARN" "$@"
+}
+
+function error() {
+    echo -ne "${C_BOLD}${C_RED}ERROR:${C_RESET} " >&2
+    _output "$@"
+    log "ERROR" "$@"
+}
+
+function fatal() {
+    error "$@"
+    exit 1
+}
+
+function log() {
+    local level="$1"
+    shift
+    local timeStamp="$(date "+%Y-%m-%d %H:%M:%S")"
+
+    for line in "$@"; do
+        if [[ -n "$line" ]]; then
+            echo -e "[$timeStamp] $level - $line" >> "$NIMBUS_LOG_FILE"
+        fi
+    done
+}
+
+function log_prune() {
+    local tmpFile="${NIMBUS_LOG_FILE}.tmp"
+
+    tail -n $NIMBUS_LOG_LINES "$NIMBUS_LOG_FILE" > "$tmpFile"
+    mv -f "$tmpFile" "$NIMBUS_LOG_FILE"
+}
+
 
 readonly NIMBUS_RELEASE_VERSION="UNRELEASED"
 readonly NIMBUS_RELEASE_DATE="UNRELEASED"
@@ -283,13 +343,17 @@ PRESERVE_VOLUMES=0
 
 ENV_FILE="${NIMBUS_BASEDIR}/apps.config"
 
+NIMBUS_LOG_FILE="${NIMBUS_LOG_FILE-${NIMBUS_BASEDIR}/nimbusapp.log}"
+NIMBUS_LOG_LINES=10000
+
+log "CMD" "$0 $*"
+
 if [[ "$1" != "-"* ]]; then
     IMAGE="$1"
 
     shift
     if [[ "${IMAGE}" = *"help"* ]]; then
         usage
-        exit 0
     fi
 
     if [[ "${IMAGE}" = *"version"* ]]; then
@@ -305,7 +369,6 @@ while [[ "$1" != "" ]]; do
     case "$PARAM" in
     -h | --help | help)
         usage
-        exit 0
         ;;
     --version)
         version_info
@@ -331,7 +394,7 @@ while [[ "$1" != "" ]]; do
             VOLUME_MOUNT_IDEA="\ \ \ \ - type: bind\n\ \ \ \ \ \ source: ${HOME}\/${IDEA}\n\ \ \ \ \ \ target: \/home\/demo/\/IdeaProjects"
             create_intellij_mount_points
         else
-            output "The '-v' option is only available with Intellij at this time.  Ignoring."
+            warn "The '-v' option is only available with Intellij at this time.  Ignoring."
         fi
         shift
         ;;
@@ -343,7 +406,7 @@ while [[ "$1" != "" ]]; do
             VOLUME_MOUNT_M2="\ \ \ \ - type: bind\n\ \ \ \ \ \ source: ${HOME}\/\.m2\n\ \ \ \ \ \ target: \/home\/demo\/\.m2"
             create_intellij_mount_points
         else
-            output "The '-m' option is only available with Intellij at this time.  Ignoring."
+            warn "The '-m' option is only available with Intellij at this time.  Ignoring."
         fi
         shift
         ;;
@@ -390,26 +453,23 @@ while [[ "$1" != "" ]]; do
         break
         ;;
     *)
-        output "Invalid argument passed: $1"
-        usage
-        exit 1
+        usage "Invalid argument passed: $1"
     esac
 done
 
 if [[ "$IMAGE" == */* ]]; then
-    IFS=/ read REPOSITORY IMAGE <<< $IMAGE
+    IFS=/ read REPOSITORY IMAGE <<< "$IMAGE"
 fi
 
 if [[ "$IMAGE" == *:* ]]; then
-    IFS=: read IMAGE VERSION <<< $IMAGE
+    IFS=: read IMAGE VERSION <<< "$IMAGE"
 fi
 
 #create a project name for the docker-compose based on the image name.
 if [[ -z $PROJECT ]]; then
 
     if [[ -z $IMAGE ]]; then
-        echo "ERROR: Please specify an image or project name." >&2
-        exit 1;
+        usage "Please specify an image or project name."
     fi
 
     PROJECT="${IMAGE%.dockerapp}"
@@ -421,13 +481,12 @@ fi
 
 
 if [[ -z $VERSION ]]; then
-    echo "No version number specified!" >&2
-    echo >&2
-    echo "If this is your first time using $IMAGE, please specify a version number:" >&2
-    echo "    $0 $IMAGE:<version_number> ${COMPOSE_ACTION:-$DOCKERAPP_ACTION}" >&2
-    echo >&2
-    echo "The version number you choose will be remembered for future commands." >&2
-    exit 1
+    fatal "No version number specified!" \
+        "" \
+        "If this is your first time using $IMAGE, please specify a version number:" \
+            "\t$0 $IMAGE:<version_number> ${COMPOSE_ACTION:-$DOCKERAPP_ACTION}" \
+        "" \
+        "The version number you choose will be remembered for future commands."
 fi
 
 # Apply defaults if necessary
@@ -440,14 +499,11 @@ debug "Version: $VERSION"
 debug "Project: $PROJECT"
 
 if [[ -z $IMAGE ]]; then
-    echo "ERROR: Could not determine image name. Please specify an image or project name." >&2
-    exit 1
+    fatal "Could not determine image name. Please specify an image or project name." >&2
 fi
 
 if [[ -z "${COMPOSE_ACTION}" && -z "${DOCKERAPP_ACTION}" ]]; then
-    output "You must specify a command"
-    usage
-    exit 1
+    usage "You must specify a command"
 fi
 
 create_network
@@ -458,9 +514,9 @@ COMPOSE_FILE="${COMPOSE_DIR}/${IMAGE}.yml"
 COMPOSE_BACKUP="${COMPOSE_FILE}.bk"
 
 if [[ -n "${DOCKERAPP_ACTION}" ]]; then
-    if ! docker login; then
+    if ! docker login >&2; then
         rc=$?
-        output "Docker login failed ($rc)" >&2
+        error "Docker login failed ($rc)"
         exit $rc
     fi
 
@@ -489,7 +545,13 @@ if [[ -n "${DOCKERAPP_ACTION}" ]]; then
                 mv -f ${BASH_VERBOSE} "${COMPOSE_BACKUP}" "${COMPOSE_FILE}"
             fi
 
-            output "ERROR: Could not render" >&2
+            error "Could not render"
+
+            if [[ "${VERSION}" == *"_"* ]]; then
+                warn "Image name contains an underscore which is  not used by nimbusapp." \
+                    "Try using ${REPOSITORY}/${IMAGE}:${VERSION%%_*} instead"
+            fi
+
             exit 1
         fi # eval
 
@@ -509,8 +571,7 @@ if [[ -n "${DOCKERAPP_ACTION}" ]]; then
         fi
     else # curl check
         if [[ ! -f "${COMPOSE_FILE}" ]]; then
-            output "ERROR: No connection to Docker Hub: ${NIMBUS_DOCKERHUB_URL} (${NIMBUS_DOCKERHUB_TIMEOUT}s)" >&2
-            exit 1
+            fatal "ERROR: No connection to Docker Hub: ${NIMBUS_DOCKERHUB_URL} (${NIMBUS_DOCKERHUB_TIMEOUT}s)"
         else
             output "No connection to Docker Hub, using cached file!"
             debug "Docker Hub: ${NIMBUS_DOCKERHUB_URL} Timeout: ${NIMBUS_DOCKERHUB_TIMEOUT}"
@@ -520,8 +581,7 @@ if [[ -n "${DOCKERAPP_ACTION}" ]]; then
 fi
 
 if [[ ! -f "$COMPOSE_FILE" ]]; then
-    echo -e "${C_RED}ERROR${C_REG}: Could not find ${IMAGE}:${VERSION} (${PROJECT}) - do you need to create it with \`nimbusapp up'" >&2
-    exit 1
+    fatal "Could not find ${IMAGE}:${VERSION} (${PROJECT}) - do you need to create it with \`nimbusapp up'"
 fi
 
 if [[ "$COMPOSE_ACTION" == "down" && "$NIMBUS_FORCE" -eq 0 ]]; then
@@ -551,9 +611,10 @@ if [[ -n "${COMPOSE_ACTION}" ]]; then
 
     if ! eval "${COMPOSE_COMMAND}"; then
         rc=$?
-        echo "Failed to run compose: $rc" >&2
+        error "Failed to run compose: $rc"
         exit $rc
     fi
 fi
 
 apps_save
+log_prune

--- a/tests/30_recreate.bats
+++ b/tests/30_recreate.bats
@@ -87,3 +87,17 @@ function assert_message() {
 
     assert_message "force"
 }
+
+@test "Recreate: --force-recreate" {
+    run "$NIMBUS_EXE" "$TEST_IMAGE" -s "MESSAGE=force-recreate" -d up --force-recreate
+
+    (( stauts == 0 ))
+
+    assert_not_output_contains "The following containers will be recreated:"
+    assert_not_output_contains "- /nimbusapp-test-web" 
+    assert_not_output_contains "Recreate the listed containers? \[y/n\]"
+
+    assert_output_contains "Recreating nimbusapp-test-web ... done"
+
+    assert_message "force-recreate"
+}

--- a/tests/90_1.3.1.bats
+++ b/tests/90_1.3.1.bats
@@ -31,14 +31,11 @@ function teardown() {
     
     cat "$logFile"
 
-    grep "CMD - .* $TEST_IMAGE -s MESSAGE=$num -f up" $logFile
+    grep "CMD - .* $TEST_IMAGE -s MESSAGE=$num -f up" "$logFile"
     
-    grep "DEBUG - -s MESSAGE=$num" $logFile
+    grep "DEBUG - -s MESSAGE=$num" "$logFile"
 
-    grep "DEBUG - Repository: admpresales" $logFile
-    grep "DEBUG - Image: nimbusapp-test" $logFile
-    grep "DEBUG - Version: 0.1.0" $logFile
-    grep "DEBUG - Project: nimbusapp-test" $logFile
+    grep "INFO - nimbusapp-test: Using admpresales/nimbusapp-test:0.1.0" "$logFile"
 }
 
 @test "v1.3.1: No Version Message" {

--- a/tests/90_1.3.1.bats
+++ b/tests/90_1.3.1.bats
@@ -21,7 +21,7 @@ function teardown() {
     fi
 }
 
-@test "Logging" {
+@test "v1.3.1: Logging" {
     local logFile="$NIMBUS_BASEDIR/nimbusapp.log"
     local num="$RANDOM"
 
@@ -41,7 +41,7 @@ function teardown() {
     grep "DEBUG - Project: nimbusapp-test" $logFile
 }
 
-@test "No Version Message" {
+@test "v1.3.1: No Version Message" {
     run "$NIMBUS_EXE" "some_image" -f up
 
     (( status != 0 ))
@@ -50,7 +50,7 @@ function teardown() {
     assert_output_contains "If this is your first time using some_image, please specify a version number"
 }
 
-@test "Underscore Error" {
+@test "v1.3.1: Underscore Error" {
     run "$NIMBUS_EXE" "octane:test_wrong" -f up
 
     (( status != 0 ))

--- a/tests/90_1.3.1.bats
+++ b/tests/90_1.3.1.bats
@@ -35,7 +35,7 @@ function teardown() {
     
     grep "DEBUG - -s MESSAGE=$num" "$logFile"
 
-    grep "INFO - nimbusapp-test: Using admpresales/nimbusapp-test:0.1.0" "$logFile"
+    grep "INFO - Using admpresales/nimbusapp-test.dockerapp:0.1.0" "$logFile"
 }
 
 @test "v1.3.1: No Version Message" {

--- a/tests/90_1.3.1.bats
+++ b/tests/90_1.3.1.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+load helper
+load docker_assert
+load output_assert
+
+function setup() {
+    export NIMBUS_BASEDIR="$BATS_TMPDIR/nimbusapp-test-131"
+
+    if is_first_test; then
+        rm -rf "$NIMBUS_BASEDIR"
+        mkdir -p "$NIMBUS_BASEDIR"
+        cleanup_containers "$TEST_CONTAINER"
+    fi
+}
+
+function teardown() {
+    if is_last_test; then
+        cleanup_containers "$TEST_CONTAINER"
+        rm -fr "$NIMBUS_BASEDIR"
+    fi
+}
+
+@test "Logging" {
+    local logFile="$NIMBUS_BASEDIR/nimbusapp.log"
+    local num="$RANDOM"
+
+    run "$NIMBUS_EXE" "$TEST_IMAGE" -s "MESSAGE=$num" -f up
+
+    (( status == 0 ))
+    
+    cat "$logFile"
+
+    grep "CMD - .* $TEST_IMAGE -s MESSAGE=$num -f up" $logFile
+    
+    grep "DEBUG - -s MESSAGE=$num" $logFile
+
+    grep "DEBUG - Repository: admpresales" $logFile
+    grep "DEBUG - Image: nimbusapp-test" $logFile
+    grep "DEBUG - Version: 0.1.0" $logFile
+    grep "DEBUG - Project: nimbusapp-test" $logFile
+}
+
+@test "No Version Message" {
+    run "$NIMBUS_EXE" "some_image" -f up
+
+    (( status != 0 ))
+
+    assert_output_contains "ERROR: No version number specified!"
+    assert_output_contains "If this is your first time using some_image, please specify a version number"
+}
+
+@test "Underscore Error" {
+    run "$NIMBUS_EXE" "octane:test_wrong" -f up
+
+    (( status != 0 ))
+
+    cat <<< "$output"
+
+    assert_output_contains "ERROR: Could not render"
+    assert_output_contains "WARNING: Image name contains an underscore which is not used by nimbusapp."
+    assert_output_contains "Try using admpresales/octane:test instead"
+}

--- a/tests/template.bats.tmpl
+++ b/tests/template.bats.tmpl
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+load helper
+load docker_assert
+
+function setup() {
+    export NIMBUS_BASEDIR="$BATS_TMPDIR/nimbusapp-test-basic"
+
+    if is_first_test; then
+        mkdir -p "$NIMBUS_BASEDIR"
+        cleanup_containers "$TEST_CONTAINER"
+    else
+        export NIMBUS_DOCKERHUB_URL="0.0.0.0:0"
+    fi
+}
+
+function teardown() {
+    if is_last_test; then
+        cleanup_containers "$TEST_CONTAINER"
+        rm -fr "$NIMBUS_BASEDIR"
+    fi
+}
+
+@test "Template" {
+
+}


### PR DESCRIPTION
### Changed
- Updated docs and usage statement
- Display full image name in up/down prompts
- Most output redirected to standard error, reserving standard output stream for docker-compose/docker-app output
- #35 Treat `--force-recreate` compose option the same as `--force`  when recreating containers
- Display which image is being used after lookup in apps.config

### Added
- Log all output and commands, defaults to: `$HOME/.nimbusapp/nimbusapp.log`
- #32 Inform user when their command failed and contained an underscore in the version. By convention underscores are currently only used in container versions, not docker applications

### Fixed
- #34 Add quotes around here string variables to prevent colons causing issues on Mac
- No longer assign default version of "latest" and fail when calling Docker Hub, instead inform the user they need to provide a version