### PR TITLE
1.3.X - Various bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,19 @@ This script is based on the images in https://hub.docker.com/u/admpresales
 
 ## Installation
 
+### Quick Install
+
+```
+wget -nv https://github.com/admpresales/nimbusapp/releases/latest/download/nimbusapp.tar.gz -O- | sudo tar -xz -C /usr/local/bin
+```
+
+### Manual Install
+
 Download the latest .tar.gz release from https://github.com/admpresales/nimbusapp/releases by executing the following commands from a terminal window:
 
 ```
 [demo@nimbusserver ~]$ cd ~/Downloads
+[demo@nimbusserver ~]$ rm -f nimbusapp.tar.gz*
 [demo@nimbusserver Downloads]$ wget -nv https://github.com/admpresales/nimbusapp/releases/latest/download/nimbusapp.tar.gz
 
 ```

--- a/nimbusapp
+++ b/nimbusapp
@@ -123,7 +123,7 @@ function apps_save() {
     debug "Saving: $PROJECT $REPOSITORY $IMAGE $VERSION"
 
     # Remove previous entry for this project
-    sed -i "/$PROJECT\b/d" "$file"
+    sed -i "/$PROJECT\s/d" "$file"
 
     # Write new entry
     echo $PROJECT $REPOSITORY $IMAGE $VERSION >> "$file"
@@ -569,12 +569,12 @@ if [[ -n "${DOCKERAPP_ACTION}" ]]; then
 
         if [[ -n "${VOLUME_MOUNT_IDEA}" ]]; then
             debug "Mounting IDEA: ${VOLUME_MOUNT_IDEA}"
-            sed -i "/volumes:/a ${VOLUME_MOUNT_IDEA}" "${COMPOSE_FILE}"
+            sed -i "/\svolumes:/a ${VOLUME_MOUNT_IDEA}" "${COMPOSE_FILE}"
         fi
 
         if [[ -n "${VOLUME_MOUNT_M2}" ]]; then
             debug "Mounting M2: ${VOLUME_MOUNT_M2}"
-            sed -i "/volumes:/a ${VOLUME_MOUNT_M2}" "${COMPOSE_FILE}"
+            sed -i "/\svolumes:/a ${VOLUME_MOUNT_M2}" "${COMPOSE_FILE}"
         fi
 
 
@@ -621,7 +621,7 @@ if [[ -n "${COMPOSE_ACTION}" ]]; then
 
     debug "Running: ${COMPOSE_COMMAND}"
 
-    if ! eval "${COMPOSE_COMMAND} 2>&1 | tee -a '$NIMBUS_LOG_FILE'"; then
+    if ! eval "${COMPOSE_COMMAND}"; then
         rc=$?
         error "Failed to run compose: $rc"
         exit $rc

--- a/tests/40_config.bats
+++ b/tests/40_config.bats
@@ -33,6 +33,10 @@ EOF
     # Cannot use $TEST_IMAGE here
     run "$NIMBUS_EXE" nimbusapp-test -d -f up
     (( status == 0 ))
+
+    # Ensure nothing gets deleted
+    grep "nimbusapp-test\s" "$NIMBUS_BASEDIR/apps.config"
+    grep "nimbusapp-test-fake\s" "$NIMBUS_BASEDIR/apps.config"
 }
 
 @test "Config: Remember" {


### PR DESCRIPTION
- Stop logging compose output, this prevented progress bars from being displayed
- Use space instead of word break as delimiter when removing lines from apps.config
- Do not append container-specific volume information to top-level volumes section
- Documentation update to handle an existing nimbusapp.tar.gz file in the Downloads directory